### PR TITLE
Add FastAPI load balancer service for MLNode inference

### DIFF
--- a/mlnode/packages/load_balancer/README.md
+++ b/mlnode/packages/load_balancer/README.md
@@ -1,0 +1,35 @@
+# MLNode Load Balancer
+
+This service provides a lightweight FastAPI-based proxy that sits in front of multiple
+MLNode instances. It keeps track of their health and current state and exposes
+aggregated `/api/v1/state` and `/health` endpoints. Requests hitting inference
+routes (`/v1/*`) are routed to the least-busy healthy backend that reports the
+`INFERENCE` state.
+
+## Configuration
+
+The balancer is configured through environment variables:
+
+- `MLNODE_BACKENDS` – comma-separated list of MLNode base URLs (required).
+- `MLNODE_REFRESH_INTERVAL` – monitor refresh interval in seconds (default `2.0`).
+- `MLNODE_REQUEST_TIMEOUT` – upstream request timeout in seconds (default `30.0`).
+- `MLNODE_STATE_TIMEOUT` – timeout for state checks (default `5.0`).
+- `MLNODE_HEALTH_TIMEOUT` – timeout for health checks (default `2.0`).
+
+## Development
+
+Install dependencies with poetry and run the FastAPI app with uvicorn:
+
+```bash
+poetry install
+MLNODE_BACKENDS=http://mlnode1:8080,http://mlnode2:8080 \
+    uvicorn load_balancer.app:app --reload --host 0.0.0.0 --port 8080
+```
+
+## Behaviour
+
+- `/api/v1/state` responds with the aggregated state and a breakdown per backend.
+- `/health` returns `200` if at least one backend is healthy and running inference.
+- `/v1/*` requests are proxied to the least busy healthy backend.
+- Any other paths are forwarded to the first configured backend for backward
+  compatibility.

--- a/mlnode/packages/load_balancer/pyproject.toml
+++ b/mlnode/packages/load_balancer/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "mlnode-load-balancer"
+version = "0.1.0"
+description = "Lightweight load balancer in front of MLNode instances"
+readme = "README.md"
+authors = [
+    "Gonka AI"
+]
+packages = [{include = "load_balancer", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = ">=0.115.8"
+httpx = ">=0.27.0"
+uvicorn = ">=0.34.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
+pytest-asyncio = "^0.23"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/mlnode/packages/load_balancer/src/load_balancer/__init__.py
+++ b/mlnode/packages/load_balancer/src/load_balancer/__init__.py
@@ -1,0 +1,5 @@
+"""MLNode load balancer package."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/mlnode/packages/load_balancer/src/load_balancer/app.py
+++ b/mlnode/packages/load_balancer/src/load_balancer/app.py
@@ -1,0 +1,189 @@
+"""FastAPI application exposing the MLNode load balancer."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+from starlette.background import BackgroundTask
+
+from .backends import BackendPool
+from .config import Settings
+from .monitor import monitor_backend
+
+SUPPORTED_METHODS = [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
+    "HEAD",
+]
+
+
+async def _proxy_request(
+    request: Request,
+    backend_pool: BackendPool,
+    client: httpx.AsyncClient,
+    mount_path: str,
+) -> Response:
+    try:
+        backend = await backend_pool.pick_backend()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    target_path = request.url.path
+    if mount_path:
+        target_path = target_path[len(mount_path) :]
+        if not target_path.startswith("/"):
+            target_path = "/" + target_path
+
+    url = f"{backend.url}{target_path}"
+    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+
+    async def _body_iterator():
+        async for chunk in request.stream():
+            yield chunk
+
+    context = client.stream(
+        request.method,
+        url,
+        params=request.query_params,
+        headers=headers,
+        content=_body_iterator(),
+        timeout=httpx.Timeout(None, read=backend_pool.settings.request_timeout),
+    )
+    try:
+        upstream = await context.__aenter__()
+
+        filtered_headers = {
+            key: value
+            for key, value in upstream.headers.items()
+            if key.lower() not in {"content-length", "transfer-encoding", "connection"}
+        }
+
+        async def _cleanup():
+            try:
+                await context.__aexit__(None, None, None)
+            finally:
+                await backend_pool.release_backend(backend)
+
+        return StreamingResponse(
+            upstream.aiter_raw(),
+            status_code=upstream.status_code,
+            headers=filtered_headers,
+            background=BackgroundTask(_cleanup),
+        )
+    except Exception as exc:
+        with contextlib.suppress(Exception):
+            await context.__aexit__(None, None, None)
+        await backend_pool.release_backend(backend)
+        raise HTTPException(status_code=502, detail="Upstream request failed") from exc
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    settings = Settings.load()
+    pool = BackendPool(settings)
+    client = httpx.AsyncClient(http2=True)
+    monitor_tasks = [asyncio.create_task(monitor_backend(backend, client)) for backend in pool]
+
+    app.state.settings = settings
+    app.state.backend_pool = pool
+    app.state.http_client = client
+    app.state.monitor_tasks = monitor_tasks
+
+    try:
+        yield
+    finally:
+        for task in monitor_tasks:
+            task.cancel()
+        await asyncio.gather(*monitor_tasks, return_exceptions=True)
+        await client.aclose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/api/v1/state")
+async def get_state(request: Request):
+    pool: BackendPool = request.app.state.backend_pool
+    return JSONResponse(pool.to_dict())
+
+
+@app.get("/health")
+async def health(request: Request):
+    pool: BackendPool = request.app.state.backend_pool
+    if not pool.any_healthy():
+        raise HTTPException(status_code=503, detail="No healthy inference backends")
+    return JSONResponse({"status": "healthy"})
+
+
+@app.api_route("/v1/{path:path}", methods=SUPPORTED_METHODS)
+async def proxy_inference(path: str, request: Request):
+    pool: BackendPool = request.app.state.backend_pool
+    client: httpx.AsyncClient = request.app.state.http_client
+    return await _proxy_request(request, pool, client, mount_path="")
+
+
+@app.api_route("/{path:path}", methods=SUPPORTED_METHODS, include_in_schema=False)
+async def proxy_fallback(path: str, request: Request):
+    pool: BackendPool = request.app.state.backend_pool
+    client: httpx.AsyncClient = request.app.state.http_client
+    # For non-inference routes just proxy to the first backend to maintain compatibility.
+    backend = next(iter(pool.backends), None)
+    if backend is None:
+        raise HTTPException(status_code=503, detail="No MLNode backends configured")
+    # Temporarily mark backend as busy to keep accounting consistent.
+    await backend.mark_request_start()
+    path_component = request.url.path or "/"
+    url = f"{backend.url}{path_component}"
+    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+
+    async def _body_iterator():
+        async for chunk in request.stream():
+            yield chunk
+
+    context = client.stream(
+        request.method,
+        url,
+        params=request.query_params,
+        headers=headers,
+        content=_body_iterator(),
+        timeout=httpx.Timeout(None, read=pool.settings.request_timeout),
+    )
+    try:
+        upstream = await context.__aenter__()
+
+        filtered_headers = {
+            key: value
+            for key, value in upstream.headers.items()
+            if key.lower() not in {"content-length", "transfer-encoding", "connection"}
+        }
+
+        async def _cleanup():
+            try:
+                await context.__aexit__(None, None, None)
+            finally:
+                await backend.mark_request_done()
+
+        return StreamingResponse(
+            upstream.aiter_raw(),
+            status_code=upstream.status_code,
+            headers=filtered_headers,
+            background=BackgroundTask(_cleanup),
+        )
+    except Exception as exc:
+        with contextlib.suppress(Exception):
+            await context.__aexit__(None, None, None)
+        await backend.mark_request_done()
+        raise HTTPException(status_code=502, detail="Upstream request failed") from exc
+
+
+__all__ = ["app"]

--- a/mlnode/packages/load_balancer/src/load_balancer/backends.py
+++ b/mlnode/packages/load_balancer/src/load_balancer/backends.py
@@ -1,0 +1,90 @@
+"""Backend tracking primitives for the MLNode load balancer."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .config import Settings
+
+
+@dataclass
+class Backend:
+    """Represents a single MLNode backend instance."""
+
+    url: str
+    settings: Settings
+    state: Optional[str] = None
+    healthy: bool = False
+    active_requests: int = 0
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+
+    async def mark_request_start(self) -> None:
+        async with self._lock:
+            self.active_requests += 1
+
+    async def mark_request_done(self) -> None:
+        async with self._lock:
+            if self.active_requests > 0:
+                self.active_requests -= 1
+
+    def is_available(self) -> bool:
+        return self.healthy and self.state == "INFERENCE"
+
+    def to_dict(self) -> dict:
+        return {
+            "url": self.url,
+            "state": self.state,
+            "healthy": self.healthy,
+            "active_requests": self.active_requests,
+        }
+
+
+class BackendPool:
+    """Collection of MLNode backends with load balancing utilities."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.backends = [Backend(url=b, settings=settings) for b in settings.backend_urls]
+        self._pick_lock = asyncio.Lock()
+
+    def __iter__(self):
+        return iter(self.backends)
+
+    def __len__(self) -> int:
+        return len(self.backends)
+
+    async def pick_backend(self) -> Backend:
+        """Return the healthiest backend with the least active requests."""
+        async with self._pick_lock:
+            candidates = [b for b in self.backends if b.is_available()]
+            if not candidates:
+                raise RuntimeError("No healthy inference backends available")
+
+            backend = min(candidates, key=lambda b: b.active_requests)
+            await backend.mark_request_start()
+            return backend
+
+    async def release_backend(self, backend: Backend) -> None:
+        await backend.mark_request_done()
+
+    def aggregate_state(self) -> str:
+        states = [b.state for b in self.backends if b.state]
+        priority = ["INFERENCE", "POW", "TRAIN", "STOPPED"]
+        for state in priority:
+            if state in states:
+                return state
+        return "STOPPED"
+
+    def any_healthy(self) -> bool:
+        return any(b.is_available() for b in self.backends)
+
+    def to_dict(self) -> dict:
+        return {
+            "state": self.aggregate_state(),
+            "nodes": [b.to_dict() for b in self.backends],
+        }
+
+
+__all__ = ["Backend", "BackendPool"]

--- a/mlnode/packages/load_balancer/src/load_balancer/config.py
+++ b/mlnode/packages/load_balancer/src/load_balancer/config.py
@@ -1,0 +1,53 @@
+"""Configuration utilities for the MLNode load balancer service."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List
+
+DEFAULT_REFRESH_INTERVAL = 2.0
+DEFAULT_REQUEST_TIMEOUT = 30.0
+DEFAULT_STATE_TIMEOUT = 5.0
+DEFAULT_HEALTH_TIMEOUT = 2.0
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration for the load balancer."""
+
+    backend_urls: List[str]
+    refresh_interval: float = DEFAULT_REFRESH_INTERVAL
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT
+    state_timeout: float = DEFAULT_STATE_TIMEOUT
+    health_timeout: float = DEFAULT_HEALTH_TIMEOUT
+
+    @classmethod
+    def load(cls) -> "Settings":
+        """Load configuration from environment variables."""
+        raw_backends = os.getenv("MLNODE_BACKENDS", "")
+        backends = [b.strip().rstrip("/") for b in raw_backends.split(",") if b.strip()]
+        if not backends:
+            raise RuntimeError(
+                "MLNODE_BACKENDS environment variable must contain at least one backend URL"
+            )
+
+        def _float_env(name: str, default: float) -> float:
+            raw = os.getenv(name)
+            if raw is None:
+                return default
+            try:
+                return float(raw)
+            except ValueError as exc:
+                raise RuntimeError(f"Invalid float value for {name}: {raw}") from exc
+
+        return cls(
+            backend_urls=backends,
+            refresh_interval=_float_env("MLNODE_REFRESH_INTERVAL", DEFAULT_REFRESH_INTERVAL),
+            request_timeout=_float_env("MLNODE_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT),
+            state_timeout=_float_env("MLNODE_STATE_TIMEOUT", DEFAULT_STATE_TIMEOUT),
+            health_timeout=_float_env("MLNODE_HEALTH_TIMEOUT", DEFAULT_HEALTH_TIMEOUT),
+        )
+
+
+__all__ = ["Settings"]

--- a/mlnode/packages/load_balancer/src/load_balancer/monitor.py
+++ b/mlnode/packages/load_balancer/src/load_balancer/monitor.py
@@ -1,0 +1,44 @@
+"""Background monitoring for MLNode backends."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from .backends import Backend
+
+
+async def _fetch_json(client: httpx.AsyncClient, url: str, timeout: float) -> dict | None:
+    try:
+        response = await client.get(url, timeout=timeout)
+    except Exception:
+        return None
+    if response.status_code != 200:
+        return None
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+async def _fetch_status(client: httpx.AsyncClient, url: str, timeout: float) -> bool:
+    try:
+        response = await client.get(url, timeout=timeout)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+async def monitor_backend(backend: Backend, client: httpx.AsyncClient) -> None:
+    """Continuously update backend state and health."""
+    settings = backend.settings
+    state_url = f"{backend.url}/api/v1/state"
+    health_url = f"{backend.url}/health"
+
+    while True:
+        state_data = await _fetch_json(client, state_url, settings.state_timeout)
+        backend.state = state_data.get("state") if state_data else None
+        backend.healthy = await _fetch_status(client, health_url, settings.health_timeout)
+        await asyncio.sleep(settings.refresh_interval)
+

--- a/mlnode/pyproject.toml
+++ b/mlnode/pyproject.toml
@@ -15,6 +15,7 @@ mlnode-common = {path = "packages/common", develop = true}
 mlnode-pow = {path = "packages/pow", develop = true}
 mlnode-train = {path = "packages/train", develop = true}
 mlnode-api = {path = "packages/api", develop = true}
+mlnode-load-balancer = {path = "packages/load_balancer", develop = true}
 benchmarks = {path = "packages/benchmarks", develop = true}
 
 pytest = "^7.4.3"


### PR DESCRIPTION
## Summary
- add a new FastAPI-based load balancer service in packages/load_balancer
- track the health and state of multiple MLNodes and expose aggregated /api/v1/state and /health endpoints
- proxy inference traffic to the least busy healthy backend while falling back to the first node for other routes

## Testing
- python -m compileall mlnode/packages/load_balancer/src/load_balancer

------
https://chatgpt.com/codex/tasks/task_e_68da91576a4c8325aa2a7c42ba3e1f92